### PR TITLE
Point Waterline at our waterline-schema fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "async": "~0.9.0",
     "bluebird": "^2.3.4",
     "deep-diff": "~0.1.7",
-    "lodash": "~2.4.1",
+    "lodash": "2.4.1",
     "node-switchback": "~0.1.0",
     "prompt": "~0.2.12",
     "waterline-criteria": "~0.11.0",
-    "waterline-schema": "~0.1.16"
+    "waterline-schema": "git://github.com/Shyp/waterline-schema.git#shyp-master-0.1.17"
   },
   "devDependencies": {
     "mocha": "^2.3.4",
@@ -21,10 +21,7 @@
   "keywords": [
     "mvc",
     "orm",
-    "mysql",
     "postgresql",
-    "redis",
-    "mongodb",
     "active-record",
     "waterline",
     "sails",
@@ -34,8 +31,7 @@
   "main": "./lib/waterline",
   "scripts": {
     "test": "mocha test --recursive",
-    "prepublish": "npm prune",
-    "browserify": "rm -rf .dist && mkdir .dist && browserify lib/waterline.js -s Waterline | uglifyjs > .dist/waterline.min.js"
+    "prepublish": "npm prune"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
This replaces Balderdash's waterline-schema with our fork, at exactly the same
version (0.1.17).

I might need to shrinkwrap this, will test after I repoint.
