### PR TITLE
Lock down package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,18 +5,18 @@
   "homepage": "https://github.com/Shyp/waterline",
   "dependencies": {
     "anchor": "git://github.com/Shyp/anchor.git#shyp-master-0.10.2",
-    "async": "~0.9.0",
-    "bluebird": "^2.3.4",
-    "deep-diff": "~0.1.7",
-    "lodash": "~2.4.1",
-    "node-switchback": "~0.1.0",
-    "prompt": "~0.2.12",
-    "waterline-criteria": "~0.11.0",
+    "async": "0.9.0",
+    "bluebird": "2.9.24",
+    "deep-diff": "0.1.7",
+    "lodash": "2.4.1",
+    "node-switchback": "0.1.2",
+    "prompt": "0.2.14",
+    "waterline-criteria": "0.11.1",
     "waterline-schema": "git://github.com/Shyp/waterline-schema.git#shyp-master-0.1.17"
   },
   "devDependencies": {
     "mocha": "^2.3.4",
-    "should": "~2.1.1"
+    "should": "^7.1.0"
   },
   "keywords": [
     "mvc",


### PR DESCRIPTION
This locks each package at its equivalent version in the Shyp API
