### PR TITLE
Add NPM Shrinkwrap file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: install test
+
+install:
+	npm install
+
+test:
+	mocha test --recursive

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,159 @@
+{
+  "name": "waterline",
+  "version": "1.0.0",
+  "dependencies": {
+    "anchor": {
+      "version": "0.10.2",
+      "resolved": "git://github.com/Shyp/anchor.git#6c0c1edc1c88af857336b014a4508d93a8b33bf5",
+      "dependencies": {
+        "validator": {
+          "version": "3.22.2"
+        }
+      }
+    },
+    "async": {
+      "version": "0.9.0"
+    },
+    "bluebird": {
+      "version": "2.9.24"
+    },
+    "deep-diff": {
+      "version": "0.1.7"
+    },
+    "lodash": {
+      "version": "2.4.1"
+    },
+    "node-switchback": {
+      "version": "0.1.2"
+    },
+    "prompt": {
+      "version": "0.2.14",
+      "dependencies": {
+        "pkginfo": {
+          "version": "0.3.0"
+        },
+        "read": {
+          "version": "1.0.7",
+          "dependencies": {
+            "mute-stream": {
+              "version": "0.0.5"
+            }
+          }
+        },
+        "revalidator": {
+          "version": "0.1.8"
+        },
+        "utile": {
+          "version": "0.2.1",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10"
+            },
+            "deep-equal": {
+              "version": "1.0.0"
+            },
+            "i": {
+              "version": "0.3.3"
+            },
+            "mkdirp": {
+              "version": "0.5.0",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8"
+                }
+              }
+            },
+            "ncp": {
+              "version": "0.4.2"
+            },
+            "rimraf": {
+              "version": "2.3.2",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1"
+                    },
+                    "minimatch": {
+                      "version": "2.0.4",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "winston": {
+          "version": "0.8.3",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10"
+            },
+            "colors": {
+              "version": "0.6.2"
+            },
+            "cycle": {
+              "version": "1.0.3"
+            },
+            "eyes": {
+              "version": "0.1.8"
+            },
+            "isstream": {
+              "version": "0.1.2"
+            },
+            "stack-trace": {
+              "version": "0.0.9"
+            }
+          }
+        }
+      }
+    },
+    "waterline-criteria": {
+      "version": "0.11.1",
+      "dependencies": {
+        "include-all": {
+          "version": "0.1.6",
+          "dependencies": {
+            "underscore.string": {
+              "version": "2.3.1"
+            }
+          }
+        }
+      }
+    },
+    "waterline-schema": {
+      "version": "0.1.17",
+      "resolved": "git://github.com/Shyp/waterline-schema.git#2c228532f3d480b6dc2bfdd5911d10015abc515d"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sails",
     "sails.js"
   ],
-  "repository": "git://github.com/balderdashy/waterline.git",
+  "repository": "git://github.com/Shyp/waterline.git",
   "main": "./lib/waterline",
   "scripts": {
     "test": "mocha test --recursive",


### PR DESCRIPTION
This is mostly copied from the Shyp API's shrinkwrap - the dependencies should
all match up. This helps us keep a stable shrinkwrap file when we repoint this
dependency.
