### PR TITLE
Update waterline-schema

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -152,8 +152,8 @@
       }
     },
     "waterline-schema": {
-      "version": "0.1.17",
-      "resolved": "git://github.com/Shyp/waterline-schema.git#2c228532f3d480b6dc2bfdd5911d10015abc515d"
+      "version": "0.2.0",
+      "resolved": "git://github.com/Shyp/waterline-schema.git#d1a33deea5fe67bff40934e962f4aff4d11b671a"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "node-switchback": "0.1.2",
     "prompt": "0.2.14",
     "waterline-criteria": "0.11.1",
-    "waterline-schema": "git://github.com/Shyp/waterline-schema.git#shyp-master-0.1.17"
+    "waterline-schema": "git://github.com/Shyp/waterline-schema.git#v0.2.0"
   },
   "devDependencies": {
     "mocha": "^2.3.4",

--- a/test/integration/Collection.ddl.js
+++ b/test/integration/Collection.ddl.js
@@ -114,5 +114,3 @@ describe('calling drop', function() {
 	});
 
 });
-
-

--- a/test/integration/helpers/Collection.bootstrap.js
+++ b/test/integration/helpers/Collection.bootstrap.js
@@ -23,6 +23,7 @@ module.exports = function (options) {
       _.merge({
         attributes: {},
         connection: 'my_foo',
+        migrate: 'alter',
         tableName: 'tests',
         schema: false
       }, options.properties || {})
@@ -39,7 +40,7 @@ module.exports = function (options) {
 
     waterline.initialize({ adapters: { barbaz: options.adapter }, connections: connections }, function(err, ocean) {
       if (err) return done(err);
-      
+
       // Save access to all collections + connections
       self.ocean = ocean;
 


### PR DESCRIPTION
Notably, change the default migration strategy from 'alter' to 'safe'. This
will let us remove all of the 'alter' related code from Waterline.

Diff: https://github.com/Shyp/waterline-schema/compare/shyp-master-0.1.17...v0.2.0
