### PR TITLE
Use async.map instead of async.each

### DIFF
--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -59,7 +59,7 @@ module.exports = {
       });
     }
 
-    async.each(valuesList, create, function(err) {
+    async.map(valuesList, create, function(err) {
       if(err) return cb(err);
       cb(null, records);
     });


### PR DESCRIPTION
Like async.each, async.map hits the callback for each list item concurrently,
but arranges the return values in the same order they were passed in, instead
of in a random order.

This fixes https://github.com/balderdashy/sails-postgresql/issues/128 and is
backported from upstream Waterline.
