### PR TITLE
Actually use the output of async.map

### DIFF
--- a/lib/waterline/query/aggregate.js
+++ b/lib/waterline/query/aggregate.js
@@ -48,20 +48,7 @@ module.exports = {
     var errStr = _validateValues(_.cloneDeep(valuesList));
     if(errStr) return usageError(errStr, usage, cb);
 
-    var records = [];
-
-    function create(value, next) {
-      self.create(value, function(err, record) {
-        if(err) return next(err);
-        records.push(record);
-        next();
-      });
-    }
-
-    async.map(valuesList, create, function(err) {
-      if(err) return cb(err);
-      cb(null, records);
-    });
+    async.map(valuesList, self.create.bind(self), cb);
   },
 
 };


### PR DESCRIPTION
This backports https://github.com/balderdashy/waterline/pull/986 into Shyp's
working tree. Previously, Waterline would call `async.map` and ignore the
result, with predictable results for the array ordering.

I verified this works by applying this patch in waterline-adapter-tests and
verifying that the relevant test passes.
