### PR TITLE
Only return one error from Waterline validation

### DIFF
--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -166,29 +166,12 @@ Validator.prototype.validate = function(values, presentOnly, cb) {
 
       // Validate with Lusitania
       values.validation = validation;
-      var err = lusitania(value).to(requirements.data, values);
-
-      // If No Error return
-      if(!err) return cb();
-
-      // Build an Error Object
-      errors[validation] = [];
-
-      err.forEach(function(obj) {
-        if(obj.property) delete obj.property;
-        errors[validation].push({ rule: obj.rule, message: obj.message });
-      });
-
-      return cb();
+      return cb(lusitania(value).to(requirements.data, values));
     });
 
   }
 
   // Validate all validations in parallel
-  async.each(validations, validate, function allValidationsChecked () {
-    if(Object.keys(errors).length === 0) return cb();
-
-    cb(errors);
-  });
+  async.each(validations, validate, cb);
 
 };

--- a/lib/waterline/query/validate.js
+++ b/lib/waterline/query/validate.js
@@ -38,23 +38,9 @@ module.exports = {
 
       // Run Validation
       function(cb) {
-        self._validator.validate(values, presentOnly === true, function(invalidAttributes) {
-
-          // Create validation error here
-          // (pass in the invalid attributes as well as the collection's globalId)
-          if(invalidAttributes) return cb(new WLValidationError({
-            invalidAttributes: invalidAttributes,
-            model: self.globalId
-          }));
-
-          cb();
-        });
+        self._validator.validate(values, presentOnly === true, cb);
       },
 
-    ], function(err) {
-      if(err) return cb(err);
-      cb();
-    });
-  }
-
-}
+    ], cb);
+  },
+};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15,8 +15,8 @@
       "version": "2.4.1"
     },
     "lusitania": {
-      "version": "1.1.0",
-      "resolved": "git+https://github.com/Shyp/lusitania.git#efc9692b6f32535470394b5f285b7727f3300ccc",
+      "version": "2.0.0",
+      "resolved": "git+https://github.com/Shyp/lusitania.git#b3811c273432370676e1110d3de09946a685ef22",
       "dependencies": {
         "validator": {
           "version": "3.22.2"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bluebird": "2.9.24",
     "deep-diff": "0.1.7",
     "lodash": "2.4.1",
-    "lusitania": "git+https://github.com/Shyp/lusitania.git#v1.1.0",
+    "lusitania": "git+https://github.com/Shyp/lusitania.git#v2.0.0",
     "node-switchback": "0.1.2",
     "waterline-criteria": "0.11.1",
     "waterline-schema": "git://github.com/Shyp/waterline-schema.git#v0.2.0"

--- a/test/integration/Collection.validations.js
+++ b/test/integration/Collection.validations.js
@@ -1,5 +1,7 @@
-var Waterline = require('../../lib/waterline'),
-    assert = require('assert');
+var assert = require('assert');
+require('should');
+
+var Waterline = require('../../lib/waterline');
 
 describe('Waterline Collection', function() {
 
@@ -73,8 +75,7 @@ describe('Waterline Collection', function() {
     it('should error with invalid data', function(done) {
       User.create({ name: '', email: 'foobar@gmail.com'}, function(err, user) {
         assert(!user);
-        assert(err.ValidationError);
-        assert(err.ValidationError.name[0].rule === 'required');
+        err.message.should.equal("\"required\" validation rule failed for input: ''");
         done();
       });
     });
@@ -90,8 +91,7 @@ describe('Waterline Collection', function() {
     it('should error with invalid enums on strings', function(done) {
       User.create({ name: 'foo', sex: 'other' }, function(err, user) {
         assert(!user);
-        assert(err.ValidationError);
-        assert(err.ValidationError.sex[0].rule === 'in');
+        err.message.should.equal("\"in\" validation rule failed for input: 'other'");
         done();
       });
     });
@@ -106,8 +106,7 @@ describe('Waterline Collection', function() {
     it('should error with invalid username', function(done) {
       User.create({ name: 'foo', username: 'baseball_dude' }, function(err, user) {
         assert(!user);
-        assert(err.ValidationError);
-        assert(err.ValidationError.username[0].rule === 'contains');
+        err.message.should.equal("\"contains\" validation rule failed for input: 'baseball_dude'");
         done();
       });
     });
@@ -122,8 +121,7 @@ describe('Waterline Collection', function() {
     it('should error with invalid input for custom type', function(done) {
       User.create({ name: 'foo', sex: 'male', password: 'passW0rd' }, function(err, user) {
         assert(!user);
-        assert(err.ValidationError);
-        assert(err.ValidationError.password[0].rule === 'password');
+        err.message.should.equal("`password` should be a password (instead of \"passW0rd\", which is a string)");
         done();
       });
     });

--- a/test/unit/core/core.validations.js
+++ b/test/unit/core/core.validations.js
@@ -104,20 +104,14 @@ describe('Core Validator', function() {
     it('should validate types', function(done) {
       person._validator.validate({ first_name: 27, last_name: 32 }, function(err) {
         assert(err);
-        assert(err.first_name);
-        assert(err.last_name);
-        assert(err.first_name[0].rule === 'string');
-        assert(err.last_name[0].rule === 'string');
+        err.message.should.equal("`first_name` should be a string (instead of \"27\", which is a number)");
         done();
       });
     });
 
     it('should validate required status', function(done) {
       person._validator.validate({ first_name: 'foo' }, function(err) {
-        assert(err);
-        assert(err);
-        assert(err.last_name);
-        assert(err.last_name[1].rule === 'required');
+        err.message.should.equal("`last_name` should be a string (instead of null)");
         done();
       });
     });

--- a/test/unit/validations/validation.enum.js
+++ b/test/unit/validations/validation.enum.js
@@ -20,10 +20,8 @@ describe('validations', function() {
     });
 
     it('should error if invalid enum is set', function(done) {
-      validator.validate({ sex: 'other' }, function(errors) {
-        assert(errors);
-        assert(errors.sex);
-        assert(errors.sex[0].rule === 'in');
+      validator.validate({ sex: 'other' }, function(error) {
+        error.message.should.equal("\"in\" validation rule failed for input: 'other'");
         done();
       });
     });

--- a/test/unit/validations/validations.function.js
+++ b/test/unit/validations/validations.function.js
@@ -22,7 +22,7 @@ describe('validations', function() {
           type: 'string',
           contains: function(cb) {
             setTimeout(function() {
-              return cb('http://')
+              return cb('http://');
             },1);
           }
         }
@@ -33,10 +33,8 @@ describe('validations', function() {
     });
 
     it('should error if invalid username is set', function(done) {
-      validator.validate({ name: 'Bob', username: 'bobby' }, function(errors) {
-        assert(errors);
-        assert(errors.username);
-        assert(errors.username[0].rule === 'equals');
+      validator.validate({ name: 'Bob', username: 'bobby' }, function(error) {
+        error.message.should.equal("\"equals\" validation rule failed for input: 'bobby'");
         done();
       });
     });
@@ -49,10 +47,8 @@ describe('validations', function() {
     });
 
     it('should error if invalid website is set', function(done) {
-      validator.validate({ website: 'www.google.com' }, function(errors) {
-        assert(errors);
-        assert(errors.website);
-        assert(errors.website[0].rule === 'contains');
+      validator.validate({ website: 'www.google.com' }, function(error) {
+        error.message.should.equal("\"contains\" validation rule failed for input: 'www.google.com'");
         done();
       });
     });

--- a/test/unit/validations/validations.length.js
+++ b/test/unit/validations/validations.length.js
@@ -33,9 +33,8 @@ describe('validations', function() {
       });
 
       it('should error if length is shorter', function(done) {
-        validator.validate({ firstName: 'f' }, function(errors) {
-          assert(errors);
-          assert(errors.firstName);
+        validator.validate({ firstName: 'f' }, function(error) {
+          error.message.should.equal("\"minLength\" validation rule failed for input: 'f'");
           done();
         });
       });
@@ -51,9 +50,8 @@ describe('validations', function() {
       });
 
       it('should error if length is longer', function(done) {
-        validator.validate({ lastName: 'foobar' }, function(errors) {
-          assert(errors);
-          assert(errors.lastName);
+        validator.validate({ lastName: 'foobar' }, function(error) {
+          error.message.should.equal("\"maxLength\" validation rule failed for input: 'foobar'");
           done();
         });
       });

--- a/test/unit/validations/validations.required.js
+++ b/test/unit/validations/validations.required.js
@@ -27,39 +27,31 @@ describe('validations', function() {
     });
 
     it('should error if no value is set for required string field', function(done) {
-      validator.validate({ name: '', employed: true, age: 27 }, function(errors) {
-        errors.name.length.should.equal(1);
-        errors.name[0].message.should.equal("\"required\" validation rule failed for input: ''");
-        assert(errors.name[0].rule === 'required');
+      validator.validate({ name: '', employed: true, age: 27 }, function(error) {
+        error.should.have.properties({
+          message: "\"required\" validation rule failed for input: ''",
+          rule: 'required',
+          data: '',
+        });
         done();
       });
     });
 
     it('should error if null is set for required string field', function(done) {
-      validator.validate({ name: null, employed: true, age: 27 }, function(errors) {
-        errors.name.length.should.equal(2);
-        errors.name[0].message.should.equal("`name` should be a string (instead of null)");
-        errors.name[0].rule.should.equal('string');
+      validator.validate({ name: null, employed: true, age: 27 }, function(error) {
+        error.should.have.properties({
+          message: "`name` should be a string (instead of null)",
+          data: null,
+          actualType: 'object',
+          expectedType: 'string',
+        });
         done();
       });
     });
 
     it('should error if no value is set for required boolean field', function(done) {
-      validator.validate({ name: 'Frederick P. Frederickson', age: 27 }, function(errors) {
-        assert(errors);
-        assert(errors.employed);
-        assert(errors.employed[0].rule === 'boolean');
-        assert(errors.employed[1].rule === 'required');
-        done();
-      });
-    });
-
-    it('should error if no value is set for required boolean field', function(done) {
-      validator.validate({ name: 'Frederick P. Frederickson', age: 27 }, function(errors) {
-        assert(errors);
-        assert(errors.employed);
-        assert(errors.employed[0].rule === 'boolean');
-        assert(errors.employed[1].rule === 'required');
+      validator.validate({ name: 'Frederick P. Frederickson', age: 27 }, function(error) {
+        error.message.should.equal("`employed` should be a boolean (instead of null)");
         done();
       });
     });

--- a/test/unit/validations/validations.specialTypes.js
+++ b/test/unit/validations/validations.specialTypes.js
@@ -26,9 +26,8 @@ describe('validations', function() {
     });
 
     it('should error if incorrect email is passed', function(done) {
-      validator.validate({ email: 'foobar' }, function(errors) {
-        assert(errors);
-        assert(errors.email);
+      validator.validate({ email: 'foobar' }, function(error) {
+        error.message.should.equal("`email` should be a email (instead of \"foobar\", which is a string)");
         done();
       });
     });

--- a/test/unit/validations/validations.type.js
+++ b/test/unit/validations/validations.type.js
@@ -34,9 +34,8 @@ describe('validations', function() {
     });
 
     it('should error if string passed to integer type', function(done) {
-      validator.validate({ age: 'foo bar' }, function(errors) {
-        errors.age.length.should.equal(1);
-        errors.age[0].message.should.equal('`age` should be a integer (instead of "foo bar", which is a string)');
+      validator.validate({ age: 'foo bar' }, function(error) {
+        error.message.should.equal('`age` should be a integer (instead of "foo bar", which is a string)');
         done();
       });
     });


### PR DESCRIPTION
Instead of returning an array of errors sorted by property, just return one
validation error. It's possible there are more errors, but none of our API's or
UI's have room to display multiple errors, and in any event clients usually fix
one error message at a time.

Also adds validation around the error messages, previously no error messages
were being checked.
