### PR TITLE
Use the original WLValidationError

### DIFF
--- a/lib/waterline/core/validations.js
+++ b/lib/waterline/core/validations.js
@@ -166,7 +166,12 @@ Validator.prototype.validate = function(values, presentOnly, cb) {
 
       // Validate with Lusitania
       values.validation = validation;
-      return cb(lusitania(value).to(requirements.data, values));
+      result = lusitania(value).to(requirements.data, values);
+      if (result) {
+        cb(new WLValidationError(result));
+      } else {
+        cb(result);
+      }
     });
 
   }

--- a/lib/waterline/error/WLValidationError.js
+++ b/lib/waterline/error/WLValidationError.js
@@ -14,151 +14,56 @@ var _ = require('lodash');
  *
  * @extends WLError
  */
-function WLValidationError (properties) {
-
-  // Call superclass
-  WLValidationError.super_.call(this, properties);
+function WLValidationError (attributes, model) {
 
   // Ensure valid usage
-  if ( typeof this.invalidAttributes !== 'object' ) {
+  if ( typeof attributes !== 'object' ) {
     return new WLUsageError({
       reason: 'An `invalidAttributes` object must be passed into the constructor for `WLValidationError`'
     });
   }
+
+  if (!(this instanceof WLValidationError)) {
+    return new WLValidationError(attributes, model);
+  }
+
   // if ( typeof this.model !== 'string' ) {
   //   return new WLUsageError({
   //     reason: 'A `model` string (the collection\'s `globalId`) must be passed into the constructor for `WLValidationError`'
   //   });
   // }
 
-  // Customize the `reason` based on the # of invalid attributes
-  // (`reason` may not be overridden)
-  var isSingular = this.length === 1;
-  this.reason = util.format('%d attribute%s %s invalid',
-    this.length,
-    isSingular ? '' : 's',
-    isSingular ? 'is' : 'are');
-
   // Always apply the 'E_VALIDATION' error code, even if it was overridden.
   this.code = 'E_VALIDATION';
 
-  // Status may be overridden.
-  this.status = properties.status || 400;
-
   // Model should always be set.
   // (this should be the globalId of model, or "collection")
-  this.model = properties.model;
+  this.model = model;
 
-  // Ensure messages exist for each invalidAttribute
-  this.invalidAttributes = _.mapValues(this.invalidAttributes, function (rules, attrName) {
-    return _.map(rules, function (rule) {
-      if (!rule.message) {
-        rule.message = util.format('A record with that `%s` already exists (`%s`).', attrName, rule.value);
-      }
-      return rule;
-    });
-  });
+  this.message = attributes.message;
 
-  // Customize the `details`
-  this.details = util.format('Invalid attributes sent to %s:\n',this.model) +
-  _.reduce(this.messages, function (memo, messages, attrName) {
-    memo += ' • ' + attrName + '\n';
-    memo += _.reduce(messages, function (memo, message) {
-      memo += '   • ' + message + '\n';
-      return memo;
-    }, '');
-    return memo;
-  }, '');
+  if (typeof attributes.rule !== 'undefined') {
+    this.rule = attributes.rule;
+  }
 
+  if (typeof attributes.data !== 'undefined') {
+    this.data = attributes.data;
+  }
+
+  if (typeof attributes.actualType !== 'undefined') {
+    this.actualType = attributes.actualType;
+  }
+
+  if (typeof attributes.expectedType !== 'undefined') {
+    this.expectedType = attributes.expectedType;
+  }
+
+  Error.call(this);
+  Error.captureStackTrace(this, arguments.callee);
+  this.name = this.constructor.name;
 }
-util.inherits(WLValidationError, WLError);
 
-
-/**
- * `rules`
- *
- * @return {Object[Array[String]]} dictionary of validation rule ids, indexed by attribute
- */
-WLValidationError.prototype.__defineGetter__('rules', function(){
-  return _.mapValues(this.invalidAttributes, function (rules, attrName) {
-    return _.pluck(rules, 'rule');
-  });
-});
-
-
-
-
-/**
- * `messages` (aka `errors`)
- *
- * @return {Object[Array[String]]} dictionary of validation messages, indexed by attribute
- */
-WLValidationError.prototype.__defineGetter__('messages', function(){
-  return _.mapValues(this.invalidAttributes, function (rules, attrName) {
-    return _.pluck(rules, 'message');
-  });
-});
-WLValidationError.prototype.__defineGetter__('errors', function(){
-  return this.messages;
-});
-
-
-/**
- * `attributes` (aka `keys`)
- *
- * @return {Array[String]} of invalid attribute names
- */
-WLValidationError.prototype.__defineGetter__('attributes', function(){
-  return _.keys(this.invalidAttributes);
-});
-WLValidationError.prototype.__defineGetter__('keys', function(){
-  return this.attributes;
-});
-
-
-/**
- * `.length`
- *
- * @return {Integer} number of invalid attributes
- */
-WLValidationError.prototype.__defineGetter__('length', function(){
-  return this.attributes.length;
-});
-
-
-
-/**
- * `.ValidationError`
- * (backwards-compatibility)
- *
- * @return {Object[Array[Object]]} number of invalid attributes
- */
-WLValidationError.prototype.__defineGetter__('ValidationError', function(){
-  //
-  // TODO:
-  // Down the road- emit deprecation event here--
-  // (will log information about new error handling options)
-  //
-  return this.invalidAttributes;
-});
-
-
-
-/**
- * [toJSON description]
- * @type {[type]}
- */
-WLValidationError.prototype.toJSON =
-WLValidationError.prototype.toPOJO =
-function () {
-  return {
-    error: this.code,
-    status: this.status,
-    summary: this.reason,
-    model: this.model,
-    invalidAttributes: this.invalidAttributes
-  };
-};
-
+WLValidationError.prototype = Object.create(Error.prototype);
+WLValidationError.prototype.constructor = WLValidationError;
 
 module.exports = WLValidationError;

--- a/lib/waterline/error/index.js
+++ b/lib/waterline/error/index.js
@@ -78,14 +78,10 @@ function duckType(err) {
 function _isConstraintViolation(err) {
 
   // If a proper error code is specified, this error can be classified.
-  if (err && typeof err === 'object' && err.code === 'E_UNIQUE') {
-    return true;
-  }
-
   // Otherwise, there is not enough information to call this a
   // constraint violation error and provide proper explanation to
   // the architect.
-  else return false;
+  return err && typeof err === 'object' && err.code === 'E_UNIQUE';
 }
 
 
@@ -96,4 +92,3 @@ function _isConstraintViolation(err) {
 // function _isValidationError(err) {
 //   return _.isObject(err) && err.ValidationError;
 // }
-

--- a/lib/waterline/query/validate.js
+++ b/lib/waterline/query/validate.js
@@ -5,9 +5,8 @@
  * Can also be used independently
  */
 
-var _ = require('lodash'),
-    WLValidationError = require('../error/WLValidationError'),
-    async = require('async');
+var _ = require('lodash');
+var async = require('async');
 
 module.exports = {
 


### PR DESCRIPTION
The previous commit bypassed the WLValidationError entirely, but we rely on
the E_VALIDATION code in a bunch of places. So set it, and copy over other
fields from the Anchor error to the WLValidationError - specifically, we
always set `this.message` to be equal to the Anchor error message, and `rule`,
`actualType`, `expectedType`, and `data`, if they are set on the Anchor error
object. These may or may not be set, dependending on the validation failure.

In addition, avoids the `util.inherits` code, and the weird
defineGetter/defineSetter code. I copied the error construction/inheriting code
from our own Shyp API error constructing code, which seems to be doing just
fine.
