### PR TITLE
Simplify the WLError

### DIFF
--- a/lib/waterline/error/WLError.js
+++ b/lib/waterline/error/WLError.js
@@ -16,128 +16,15 @@ var _ = require('lodash');
  * @param  {Object} properties
  * @constructor {WLError}
  */
-function WLError( properties ) {
-
-  // Call super constructor (Error)
-  WLError.super_.call(this);
-
-  // Fold defined properties into the new WLError instance.
-  properties = properties||{};
-  _.extend(this, properties);
-
-  // Generate stack trace
-  // (or use `originalError` if it is a true error instance)
-  if (_.isObject(this.originalError) && this.originalError instanceof Error) {
-    this._e = this.originalError;
-  }
-  else this._e = new Error();
-
-  // Doctor up a modified version of the stack trace called `rawStack`:
-  this.rawStack = (this._e.stack.replace(/^Error(\r|\n)*(\r|\n)*/, ''));
-
-
-  // Customize `details`:
-  // Try to dress up the wrapped "original" error as much as possible.
-  // @type {String} a detailed explanation of this error
-  if (typeof this.originalError === 'string') {
-    this.details = this.originalError;
-  }
-  // Run toString() on Errors:
-  else if ( this.originalError && util.isError(this.originalError) ) {
-    this.details = this.originalError.toString();
-  }
-  // But for other objects, use util.inspect()
-  else if (this.originalError) {
-    this.details = util.inspect(this.originalError);
-  }
-
-  // If `details` is set, prepend it with "Details:"
-  if (this.details) {
-    this.details = 'Details:  '+this.details +'\n';
-  }
-
+function WLError(originalError) {
+  this.originalError = originalError;
 }
-util.inherits(WLError, Error);
-
 
 // Default properties
-WLError.prototype.status =
-500;
-WLError.prototype.code =
-'E_UNKNOWN';
-WLError.prototype.reason =
-'Encountered an unexpected error';
-WLError.prototype.details =
-'';
-
-
-/**
- * Override JSON serialization.
- * (i.e. when this error is passed to `res.json()` or `JSON.stringify`)
- *
- * For example:
- * ```json
- * {
- *   status: 500,
- *   code: 'E_UNKNOWN'
- * }
- * ```
- *
- * @return {Object}
- */
-WLError.prototype.toJSON =
-WLError.prototype.toPOJO =
-function () {
-  var obj = {
-    error: this.code,
-    status: this.status,
-    summary: this.reason,
-    raw: this.originalError
-  };
-
-  // Only include `raw` if its truthy.
-  if (!obj.raw) delete obj.raw;
-
-  return obj;
-};
-
-
-
-/**
- * Override output for `sails.log[.*]`
- *
- * @return {String}
- *
- * For example:
- * ```sh
- * Waterline: ORM encountered an unexpected error:
- * { ValidationError: { name: [ [Object], [Object] ] } }
- * ```
- */
-WLError.prototype.toLog = function () {
-  return this.inspect();
-};
-
-
-/**
- * Override output for `util.inspect`
- * (also when this error is logged using `console.log`)
- *
- * @return {String}
- */
-WLError.prototype.inspect = function () {
-  return util.format('Error (%s) :: %s\n%s\n\n%s', this.code, this.reason, this.rawStack, this.details);
-};
-
-
-
-/**
- * @return {String}
- */
-WLError.prototype.toString = function () {
-  return util.format('[Error (%s) %s]', this.code, this.reason, this.details);
-};
-
-
+WLError.prototype.status = 500;
+WLError.prototype.code = 'E_UNKNOWN';
+WLError.prototype.message = 'Encountered an unexpected error';
+WLError.prototype.reason = 'Encountered an unexpected error';
+WLError.prototype.details = '';
 
 module.exports = WLError;

--- a/lib/waterline/error/WLUsageError.js
+++ b/lib/waterline/error/WLUsageError.js
@@ -22,12 +22,9 @@ util.inherits(WLUsageError, WLError);
 
 
 // Override WLError defaults with WLUsageError properties.
-WLUsageError.prototype.code =
-'E_USAGE';
-WLUsageError.prototype.status =
-0;
-WLUsageError.prototype.reason =
-'Invalid usage';
+WLUsageError.prototype.code = 'E_USAGE';
+WLUsageError.prototype.status = 0;
+WLUsageError.prototype.reason = 'Invalid usage';
 
 
 module.exports = WLUsageError;

--- a/lib/waterline/error/index.js
+++ b/lib/waterline/error/index.js
@@ -34,7 +34,11 @@ var util = require('util'),
 module.exports = function errorify(err) {
 
   // If specified `err` is already a WLError, just return it.
-  if (typeof err === 'object' && err instanceof WLError) return err;
+  if (typeof err === 'object') {
+    if (err instanceof WLError || err instanceof WLValidationError) {
+      return err;
+    }
+  }
 
   return duckType(err);
 };
@@ -61,12 +65,7 @@ function duckType(err) {
   }
 
   // Unexpected miscellaneous error  (`E_UNKNOWN`)
-  //
-  // (i.e. helmet fire. The database crashed or something. Or there's an adapter
-  //  bug. Or a bug in WL core.)
-  return new WLError({
-    originalError: err
-  });
+  return new WLError(err);
 }
 
 

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -332,7 +332,7 @@ var normalize = module.exports = {
 
 
     //
-    // TODO: Make it clear that switchback support it experimental.
+    // TODO: Make it clear that switchback support is experimental.
     //
     // Push switchback support off until >= v0.11
     // or at least add a warning about it being a `stage 1: experimental`


### PR DESCRIPTION
- Avoid the complex util.inherits logic and borrow from our internal error
  handling logic
- Set the `originalError` to be the passed in properties. This should usually
  be a Postgres error
