### PR TITLE
Don't update primary key when save() ing a record

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test bail
+.PHONY: install test bail clean
 
 install:
 	npm install
@@ -8,3 +8,6 @@ test:
 
 bail:
 	mocha test --recursive --bail
+
+clean:
+	rm -rf node_modules

--- a/lib/waterline/model/lib/associationMethods/update.js
+++ b/lib/waterline/model/lib/associationMethods/update.js
@@ -57,6 +57,10 @@ var Update = module.exports = function(collection, proto, mutatedModels, cb) {
     _values = _.merge(_values, reduced);
   });
 
+  // We don't want to SET the primary key value, it's already set and we're
+  // using it in the UPDATE.
+  delete _values[primaryKey];
+
   // Update the collection with the new values
   collection.update(criteria, _values, cb);
 };

--- a/test/unit/model/save.js
+++ b/test/unit/model/save.js
@@ -59,6 +59,17 @@ describe('instance methods', function() {
       });
     });
 
+    it('should not include the primary key', function(done) {
+      var person = new model({ id: 1, name: 'original-value' });
+
+      person.name = 'only-id';
+
+      person.save(function(err) {
+        assert.deepEqual(updateValues, {name: 'only-id'});
+        done();
+      });
+    });
+
     it('should return a promise', function(done) {
       var person = new model({ id: 1, name: 'foo' });
 


### PR DESCRIPTION
Previously when calling `.save()` we'd both filter on the primary key and
attempt to set it, e.g. UPDATE users SET email='foo', id=3 WHERE id=3. We don't
want to do that; just generate `UPDATE users SET email='foo' WHERE id=3`.
