### PR TITLE
Add better validation error messages for types

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -15,8 +15,8 @@
       "version": "2.4.1"
     },
     "lusitania": {
-      "version": "2.0.0",
-      "resolved": "git+https://github.com/Shyp/lusitania.git#b3811c273432370676e1110d3de09946a685ef22",
+      "version": "2.2.0",
+      "resolved": "git+https://github.com/Shyp/lusitania.git#98ca16abd38c9b6b861b13667693c9058b41545c",
       "dependencies": {
         "validator": {
           "version": "3.22.2"

--- a/test/integration/Collection.validations.js
+++ b/test/integration/Collection.validations.js
@@ -30,9 +30,9 @@ describe('Waterline Collection', function() {
             type: 'email'
           },
 
-          sex: {
+          emailType: {
             type: 'string',
-            enum: ['male', 'female']
+            enum: ['work', 'personal']
           },
 
           username: {
@@ -75,23 +75,23 @@ describe('Waterline Collection', function() {
     it('should error with invalid data', function(done) {
       User.create({ name: '', email: 'foobar@gmail.com'}, function(err, user) {
         assert(!user);
-        err.message.should.equal("\"required\" validation rule failed for input: ''");
+        err.message.should.equal('No name was provided. Please provide a name');
         done();
       });
     });
 
     it('should support valid enums on strings', function(done) {
-      User.create({ name: 'foo', sex: 'male' }, function(err, user) {
+      User.create({ name: 'foo', emailType: 'work' }, function(err, user) {
         assert(!err);
-        assert(user.sex === 'male');
+        assert(user.emailType === 'work');
         done();
       });
     });
 
     it('should error with invalid enums on strings', function(done) {
-      User.create({ name: 'foo', sex: 'other' }, function(err, user) {
+      User.create({ name: 'foo', emailType: 'other' }, function(err, user) {
         assert(!user);
-        err.message.should.equal("\"in\" validation rule failed for input: 'other'");
+        err.message.should.equal("Invalid emailType. Input failed in validation: \'other\'");
         done();
       });
     });
@@ -106,20 +106,20 @@ describe('Waterline Collection', function() {
     it('should error with invalid username', function(done) {
       User.create({ name: 'foo', username: 'baseball_dude' }, function(err, user) {
         assert(!user);
-        err.message.should.equal("\"contains\" validation rule failed for input: 'baseball_dude'");
+        err.message.should.equal("Invalid username. Input failed contains validation: \'baseball_dude\'");
         done();
       });
     });
 
     it('should support custom type functions with the model\'s context', function(done) {
-      User.create({ name: 'foo', sex: 'male', password: 'passW0rd', passwordConfirmation: 'passW0rd' }, function(err, user) {
+      User.create({ name: 'foo', emailType: 'work', password: 'passW0rd', passwordConfirmation: 'passW0rd' }, function(err, user) {
         assert(!err);
         done();
       });
     });
 
     it('should error with invalid input for custom type', function(done) {
-      User.create({ name: 'foo', sex: 'male', password: 'passW0rd' }, function(err, user) {
+      User.create({ name: 'foo', emailType: 'work', password: 'passW0rd' }, function(err, user) {
         assert(!user);
         err.message.should.equal("`password` should be a password (instead of \"passW0rd\", which is a string)");
         done();

--- a/test/unit/validations/validation.enum.js
+++ b/test/unit/validations/validation.enum.js
@@ -1,5 +1,6 @@
-var Validator = require('../../../lib/waterline/core/validations'),
-    assert = require('assert');
+var assert = require('assert');
+
+var Validator = require('../../../lib/waterline/core/validations');
 
 describe('validations', function() {
 
@@ -9,9 +10,9 @@ describe('validations', function() {
     before(function() {
 
       var validations = {
-        sex: {
+        emailType: {
           type: 'string',
-          in: ['male', 'female']
+          in: ['work', 'personal'],
         }
       };
 
@@ -20,15 +21,15 @@ describe('validations', function() {
     });
 
     it('should error if invalid enum is set', function(done) {
-      validator.validate({ sex: 'other' }, function(error) {
-        error.message.should.equal("\"in\" validation rule failed for input: 'other'");
+      validator.validate({ emailType: 'other' }, function(error) {
+        error.message.should.equal("Invalid emailType. Input failed in validation: \'other\'");
         done();
       });
     });
 
     it('should NOT error if valid enum is set', function(done) {
-      validator.validate({ sex: 'male' }, function(errors) {
-        assert(!errors);
+      validator.validate({ emailType: 'personal' }, function(err) {
+        assert.ifError(err);
         done();
       });
     });

--- a/test/unit/validations/validations.function.js
+++ b/test/unit/validations/validations.function.js
@@ -34,7 +34,7 @@ describe('validations', function() {
 
     it('should error if invalid username is set', function(done) {
       validator.validate({ name: 'Bob', username: 'bobby' }, function(error) {
-        error.message.should.equal("\"equals\" validation rule failed for input: 'bobby'");
+        error.message.should.equal("Invalid username. Input failed equals validation: \'bobby\'");
         done();
       });
     });
@@ -48,7 +48,7 @@ describe('validations', function() {
 
     it('should error if invalid website is set', function(done) {
       validator.validate({ website: 'www.google.com' }, function(error) {
-        error.message.should.equal("\"contains\" validation rule failed for input: 'www.google.com'");
+        error.message.should.equal("Invalid website. Input failed contains validation: \'www.google.com\'");
         done();
       });
     });

--- a/test/unit/validations/validations.length.js
+++ b/test/unit/validations/validations.length.js
@@ -34,7 +34,7 @@ describe('validations', function() {
 
       it('should error if length is shorter', function(done) {
         validator.validate({ firstName: 'f' }, function(error) {
-          error.message.should.equal("\"minLength\" validation rule failed for input: 'f'");
+          error.message.should.equal("Invalid firstName. Input failed minLength validation: \'f\'");
           done();
         });
       });
@@ -51,7 +51,7 @@ describe('validations', function() {
 
       it('should error if length is longer', function(done) {
         validator.validate({ lastName: 'foobar' }, function(error) {
-          error.message.should.equal("\"maxLength\" validation rule failed for input: 'foobar'");
+          error.message.should.equal("Invalid lastName. Input failed maxLength validation: \'foobar\'");
           done();
         });
       });

--- a/test/unit/validations/validations.required.js
+++ b/test/unit/validations/validations.required.js
@@ -29,7 +29,7 @@ describe('validations', function() {
     it('should error if no value is set for required string field', function(done) {
       validator.validate({ name: '', employed: true, age: 27 }, function(error) {
         error.should.have.properties({
-          message: "\"required\" validation rule failed for input: ''",
+          message: "No name was provided. Please provide a name",
           rule: 'required',
           data: '',
         });


### PR DESCRIPTION
Upgrades lusitania to v2.2.0, which includes the column name as part of the
rule validation error message. This lets you know which field failed in the
WLValidationError without depending on a huge hacked up `invalidAttributes`
struct that no one could decipher or figure out how to use well.

The error messages aren't perfect and I'm hoping to improve on them soon, but
I think they're an improvement, especially the required, max/min and length
error messages.

Fixes tests which incorrectly encoded the belief that gender is a binary.
