### PR TITLE
clone input objects to create and update functions to avoid mutation

### DIFF
--- a/lib/waterline/query/dql/create.js
+++ b/lib/waterline/query/dql/create.js
@@ -23,6 +23,9 @@ module.exports = function(values, cb) {
 
   var self = this;
 
+  // avoid mutating the original values object
+  values = _.clone(values);
+
   // Handle Deferred where it passes criteria first
   if(arguments.length === 3) {
     var args = Array.prototype.slice.call(arguments);

--- a/lib/waterline/query/dql/update.js
+++ b/lib/waterline/query/dql/update.js
@@ -26,6 +26,9 @@ module.exports = function(criteria, values, cb) {
 
   var self = this;
 
+  // avoid mutating the original values object
+  values = _.clone(values);
+
   if(typeof criteria === 'function') {
     cb = criteria;
     criteria = null;

--- a/test/unit/callbacks/beforeCreate.create.js
+++ b/test/unit/callbacks/beforeCreate.create.js
@@ -1,5 +1,6 @@
 var Waterline = require('../../../lib/waterline'),
-    assert = require('assert');
+    assert = require('assert'),
+    should = require('should');
 
 describe('.beforeCreate()', function() {
 
@@ -50,6 +51,14 @@ describe('.beforeCreate()', function() {
         person.create({ name: 'test' }, function(err, user) {
           assert(!err);
           assert(user.name === 'test updated');
+          done();
+        });
+      });
+
+      it('should run beforeCreate and does not mutate input values', function(done) {
+        inputObject = { name: 'test' };
+        person.create(inputObject, function(err, user) {
+          inputObject.should.eql({ name: 'test' });
           done();
         });
       });

--- a/test/unit/query/query.create.js
+++ b/test/unit/query/query.create.js
@@ -1,5 +1,6 @@
 var Waterline = require('../../../lib/waterline'),
-    assert = require('assert');
+    assert = require('assert'),
+    should = require('should');
 
 describe('Collection Query', function() {
 
@@ -106,6 +107,13 @@ describe('Collection Query', function() {
         });
       });
 
+      it ('should not mutate the input object', function(done) {
+        inputObject = { name: 'Bob' };
+        query.create(inputObject, function(err, status) {
+          inputObject.should.eql ({ name: 'Bob' });
+          done();
+        });
+      });
     });
 
     describe('override auto values', function() {
@@ -152,6 +160,14 @@ describe('Collection Query', function() {
         query.create({}, function(err, status) {
           assert(!status.createdAt);
           assert(!status.updatedAt);
+          done();
+        });
+      });
+
+      it ('should not mutate the input object', function(done) {
+        inputObject = { name: 'Bob' };
+        query.create(inputObject, function(err, status) {
+          inputObject.should.eql ({ name: 'Bob' });
           done();
         });
       });

--- a/test/unit/query/query.create.nested.js
+++ b/test/unit/query/query.create.nested.js
@@ -72,6 +72,14 @@ describe('Collection Query', function() {
           done();
         });
       });
+
+      it('should not mutate the input object', function(done) {
+        inputObject = { name: 'foo', nestedModel: { name: 'joe' }};
+        query.create(inputObject, function(err, status) {
+          inputObject.should.eql ({ name: 'foo', nestedModel: { name: 'joe' }});
+          done();
+        });
+      });
     });
 
     describe('with nested collection values', function() {
@@ -150,6 +158,29 @@ describe('Collection Query', function() {
           assert(!err);
           assert(status.nestedModels.length === 0);
           assert(findValues.length === 4);
+          done();
+        });
+      });
+
+      it('should not mutate any of the models', function(done) {
+
+        var nestedModels = [
+          { name: 'joe', model: 2 },
+          { name: 'moe', model: 3 },
+          { name: 'flow', model: 4 }
+        ];
+
+        inputObject = { id: 5, name: 'foo', nestedModels: nestedModels };
+        query.create(inputObject, function(err, status) {
+          inputObject.should.eql(
+            { id: 5,
+              name: 'foo',
+              nestedModels: [
+                { name: 'joe', model: 2 },
+                { name: 'moe', model: 3 },
+                { name: 'flow', model: 4 }
+              ]
+            });
           done();
         });
       });

--- a/test/unit/query/query.createEach.js
+++ b/test/unit/query/query.createEach.js
@@ -129,6 +129,14 @@ describe('Collection Query', function() {
           done();
         });
       });
+
+      it('should not mutate the input array', function(done) {
+        inputArray = [{}, {}];
+        query.createEach(inputArray, function(err, values) {
+          inputObject.should.eql [{}, {}]
+          done();
+        });
+      });
     });
 
     describe('casting values', function() {

--- a/test/unit/query/query.update.js
+++ b/test/unit/query/query.update.js
@@ -84,6 +84,13 @@ describe('Collection Query', function() {
         });
       });
 
+      it('should not mutate the input object', function(done) {
+        inputObject = { name: 'foo'}
+        query.update({}, inputObject, function(err, status) {
+          inputObject.should.eql({ name: 'foo'});
+          done();
+        });
+      });
     });
 
     describe('casting values', function() {

--- a/test/unit/query/query.update.nested.js
+++ b/test/unit/query/query.update.nested.js
@@ -72,6 +72,14 @@ describe('Collection Query', function() {
           done();
         });
       });
+
+      it('should not mutate the input object', function(done) {
+        inputObject = { name: 'foo', nestedModel: { id: 1337, name: 'joe' }}
+        query.update({}, inputObject, function(err, status) {
+          inputObject.should.eql({ name: 'foo', nestedModel: { id: 1337, name: 'joe' }})
+          done();
+        });
+      });
     });
 
     describe('with nested collection values', function() {


### PR DESCRIPTION
waterline's create and update mutate the input object with different things (e.g. adding createdAt, updatedAt, setting defaults, etc.). This causes all sorts of problems if the input object is used anywhere after being passed to these functions. 
