### PR TITLE
Make WLError inherit from Error

### DIFF
--- a/lib/waterline/error/WLError.js
+++ b/lib/waterline/error/WLError.js
@@ -17,8 +17,18 @@ var _ = require('lodash');
  * @constructor {WLError}
  */
 function WLError(originalError) {
+  if (!(this instanceof WLError)) {
+    return new WLError(originalError);
+  }
   this.originalError = originalError;
+
+  Error.call(this);
+  Error.captureStackTrace(this, arguments.callee);
+  this.name = this.constructor.name;
 }
+
+WLError.prototype = Object.create(Error.prototype);
+WLError.prototype.constructor = WLError;
 
 // Default properties
 WLError.prototype.status = 500;

--- a/lib/waterline/error/WLValidationError.js
+++ b/lib/waterline/error/WLValidationError.js
@@ -27,12 +27,6 @@ function WLValidationError (attributes, model) {
     return new WLValidationError(attributes, model);
   }
 
-  // if ( typeof this.model !== 'string' ) {
-  //   return new WLUsageError({
-  //     reason: 'A `model` string (the collection\'s `globalId`) must be passed into the constructor for `WLValidationError`'
-  //   });
-  // }
-
   // Always apply the 'E_VALIDATION' error code, even if it was overridden.
   this.code = 'E_VALIDATION';
 


### PR DESCRIPTION
This applies the same error-inheriting logic we use in the Shyp API (and the
WLValidationError) to the WLError class. This ensures that anything checking
for an Error instance will get one when a WLError is thrown.
