### PR TITLE
Pass through Postgres originalError property

### DIFF
--- a/lib/waterline/error/WLValidationError.js
+++ b/lib/waterline/error/WLValidationError.js
@@ -52,6 +52,11 @@ function WLValidationError (attributes, model) {
     this.expectedType = attributes.expectedType;
   }
 
+  // Postgres error pass through
+  if (typeof attributes.originalError !== 'undefined') {
+    this.originalError = attributes.originalError;
+  }
+
   Error.call(this);
   Error.captureStackTrace(this, arguments.callee);
   this.name = this.constructor.name;


### PR DESCRIPTION
Previously WLValidationError inherited from WLError, so it would get the
originalError property from WLError's constructor, but now it inherits directly
from Error, so we need to pass through the `originalError` property in the
constructor. This comes up when sails-postgresql raises a uniqueness constraint
failure.
