### PR TITLE
Add logic to debug WLErrors

### DIFF
--- a/lib/waterline/error/WLError.js
+++ b/lib/waterline/error/WLError.js
@@ -2,9 +2,8 @@
  * Module dependencies
  */
 
-var util = require('util');
 var _ = require('lodash');
-
+var debug = require('debug')('waterline.error');
 
 
 /**
@@ -20,6 +19,7 @@ function WLError(originalError) {
   if (!(this instanceof WLError)) {
     return new WLError(originalError);
   }
+  debug('Creating WLError:', originalError);
   this.originalError = originalError;
 
   Error.call(this);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -42,6 +42,14 @@
     "waterline-schema": {
       "version": "0.2.0",
       "resolved": "git://github.com/Shyp/waterline-schema.git#d1a33deea5fe67bff40934e962f4aff4d11b671a"
+    },
+    "debug": {
+      "version": "2.2.0",
+      "dependencies": {
+        "ms": {
+          "version": "0.7.1"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "async": "0.9.0",
     "bluebird": "2.9.24",
+    "debug": "2.2.0",
     "deep-diff": "0.1.7",
     "lodash": "2.4.1",
     "lusitania": "git+https://github.com/Shyp/lusitania.git#v2.0.0",


### PR DESCRIPTION
We're seeing WLErrors getting thrown in funky/unexpected places. Fortunately
this is reproducible in our test stack. With this flag set, we can enable debug
mode in our test environment, and figure out what's causing these failures.
