### PR TITLE
Add uuid type with primary key coercion

### DIFF
--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -296,7 +296,7 @@ Deferred.prototype.where = function(criteria) {
 
   if(!criteria) return this;
 
-  // TODO: document and test
+  // Normalize any primary keys in criteria
   criteria = normalize.expandPK(this._context, criteria);
 
   // Normalize criteria

--- a/lib/waterline/query/deferred.js
+++ b/lib/waterline/query/deferred.js
@@ -296,6 +296,9 @@ Deferred.prototype.where = function(criteria) {
 
   if(!criteria) return this;
 
+  // TODO: document and test
+  criteria = normalize.expandPK(this._context, criteria);
+
   // Normalize criteria
   criteria = normalize.criteria(criteria);
 

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -50,6 +50,13 @@ var normalize = module.exports = {
       else if (context.attributes[pk].type == 'string') {
         coercePK = function(pk) {return String(pk).toString();};
       }
+      else if (context.attributes[pk].type == 'uuid') {
+        coercePK = function(pk) {
+          var pattern = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/i
+          var matches = pattern.exec(pk);
+          return matches && matches[0];
+        };
+      }
       // If the data type is unspecified, return the key as-is
       else {
         coercePK = function(pk) {return pk;};

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -54,7 +54,12 @@ var normalize = module.exports = {
         coercePK = function(pk) {
           var pattern = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/i
           var matches = pattern.exec(pk);
-          return matches && matches[0];
+          var uuid = matches && matches[0];
+          if (uuid) {
+            return uuid;
+          } else {
+            throw new TypeError("value '" + pk + "' cannot be coerced to UUID");
+          }
         };
       }
       // If the data type is unspecified, return the key as-is

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -50,6 +50,9 @@ var normalize = module.exports = {
       else if (context.attributes[pk].type == 'string') {
         coercePK = function(pk) {return String(pk).toString();};
       }
+
+      // If the the data type is uuid, attempt to coerce the value to a
+      // properly formatted uuid, stripping any extreneous characters from it.
       else if (context.attributes[pk].type == 'uuid') {
         coercePK = function(pk) {
           var pattern = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/i

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -51,9 +51,13 @@ var normalize = module.exports = {
         coercePK = function(pk) {return String(pk).toString();};
       }
 
-      // If the the data type is uuid, attempt to coerce the value to a
+      // If the the data type is uuid (both according to the model definition
+      // as well as the database schema) attempt to coerce the value to a
       // properly formatted uuid, stripping any extreneous characters from it.
-      else if (context.attributes[pk].type == 'uuid') {
+      else if (context.attributes[pk].type == 'uuid' &&
+               context.schema &&
+               context.schema[pk] &&
+               context.schema[pk].type == 'uuid') {
         coercePK = function(pk) {
           var pattern = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/i
           var matches = pattern.exec(pk);

--- a/lib/waterline/utils/normalize.js
+++ b/lib/waterline/utils/normalize.js
@@ -5,6 +5,8 @@ var switchback = require('node-switchback');
 var errorify = require('../error');
 var WLUsageError = require('../error/WLUsageError');
 
+var uuidPattern = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/i
+
 var normalize = module.exports = {
 
   // Expand Primary Key criteria into objects
@@ -53,14 +55,13 @@ var normalize = module.exports = {
 
       // If the the data type is uuid (both according to the model definition
       // as well as the database schema) attempt to coerce the value to a
-      // properly formatted uuid, stripping any extreneous characters from it.
+      // properly formatted uuid, stripping any extraneous characters from it.
       else if (context.attributes[pk].type == 'uuid' &&
                context.schema &&
                context.schema[pk] &&
                context.schema[pk].type == 'uuid') {
         coercePK = function(pk) {
-          var pattern = /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/i
-          var matches = pattern.exec(pk);
+          var matches = uuidPattern.exec(pk);
           var uuid = matches && matches[0];
           if (uuid) {
             return uuid;

--- a/test/unit/query/query.find.js
+++ b/test/unit/query/query.find.js
@@ -4,7 +4,7 @@ var Waterline = require('../../../lib/waterline'),
 describe('Collection Query', function() {
 
   describe('.find()', function() {
-    var query, queryOnUUID;
+    var query;
 
     before(function(done) {
 
@@ -21,24 +21,7 @@ describe('Collection Query', function() {
         }
       });
 
-      var ModelWithUUID = Waterline.Collection.extend({
-        identity: 'user_with_uuid',
-        connection: 'foo',
-        attributes: {
-          id: {
-            type: 'uuid',
-            primaryKey: true
-          },
-          name: {
-            type: 'string',
-            defaultsTo: 'Foo Bar'
-          },
-          doSomething: function() {}
-        }
-      });
-
       waterline.loadCollection(Model);
-      waterline.loadCollection(ModelWithUUID);
 
       // Fixture Adapter Def
       var adapterDef = { find: function(con, col, criteria, cb) { return cb(null, [criteria]); }};
@@ -52,7 +35,6 @@ describe('Collection Query', function() {
       waterline.initialize({ adapters: { foobar: adapterDef }, connections: connections }, function(err, colls) {
         if(err) return done(err);
         query = colls.collections.user;
-        queryOnUUID = colls.collections.user_with_uuid;
         done();
       });
     });
@@ -100,13 +82,12 @@ describe('Collection Query', function() {
       });
     });
 
-    it('should coerce uuid primary keys when using deferreds', function(done) {
-      queryOnUUID.find()
-      .where({ id: 'foo_b0aec906-81d1-401b-8622-2b01036793d5' })
+    it('should normalize primary keys when using deferreds', function(done) {
+      query.find()
+      .where({ id: '123' })
       .exec(function(err, results) {
         assert(!err);
-        assert(results[0].where.id == 'b0aec906-81d1-401b-8622-2b01036793d5');
-
+        assert(results[0].where.id === 123);
         done();
       });
     });

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -90,6 +90,31 @@ describe("Normalize utility", function() {
 
       assert(result.id === '0B6C28E0-A117-4A9E-9A0D-60F0992EDBEE');
     });
+
+    it("throws a TypeError when attempting to cast a non-uuid", function() {
+      var context = {
+        attributes: {
+          id: {
+            type: 'uuid',
+            primaryKey: true
+          }
+        }
+      };
+
+      var options = {
+        id: 'hello'
+      }
+
+      try {
+        normalize.expandPK(context, options);
+        throw new Error('wrong error');
+      } catch (e) {
+        assert(e);
+        assert(e instanceof TypeError);
+        assert(e.message === "value 'hello' cannot be coerced to UUID");
+      }
+
+    });
   });
 
 });

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -60,6 +60,11 @@ describe("Normalize utility", function() {
             type: 'uuid',
             primaryKey: true
           }
+        },
+        schema: {
+          id: {
+            type: 'uuid'
+          }
         }
       };
 
@@ -79,6 +84,11 @@ describe("Normalize utility", function() {
             type: 'uuid',
             primaryKey: true
           }
+        },
+        schema: {
+          id: {
+            type: 'uuid'
+          }
         }
       };
 
@@ -91,12 +101,42 @@ describe("Normalize utility", function() {
       assert(result.id === '0B6C28E0-A117-4A9E-9A0D-60F0992EDBEE');
     });
 
+    it("does not cast uuids with an underlying non-uuid type", function() {
+      var context = {
+        attributes: {
+          id: {
+            type: 'uuid',
+            primaryKey: true
+          }
+        },
+        schema: {
+          id: {
+            type: 'text'
+          }
+        }
+      };
+
+      var options = {
+        id: 'prefix_0b6c28e0-a117-4a9e-9a0d-60f0992edbee'
+      }
+
+      var result = normalize.expandPK(context, options);
+
+      assert(result.id === 'prefix_0b6c28e0-a117-4a9e-9a0d-60f0992edbee');
+
+    });
+
     it("throws a TypeError when attempting to cast a non-uuid", function() {
       var context = {
         attributes: {
           id: {
             type: 'uuid',
             primaryKey: true
+          }
+        },
+        schema: {
+          id: {
+            type: 'uuid'
           }
         }
       };

--- a/test/unit/utils/utils.normalize.js
+++ b/test/unit/utils/utils.normalize.js
@@ -33,4 +33,63 @@ describe("Normalize utility", function() {
 
   });
 
+  describe(".expandPK()", function() {
+    it("casts integers", function() {
+      var context = {
+        attributes: {
+          id: {
+            type: 'integer',
+            primaryKey: true
+          }
+        }
+      };
+
+      var options = {
+        id: '123'
+      }
+
+      var result = normalize.expandPK(context, options);
+
+      assert(result.id === 123);
+    });
+
+    it("casts uuids", function() {
+      var context = {
+        attributes: {
+          id: {
+            type: 'uuid',
+            primaryKey: true
+          }
+        }
+      };
+
+      var options = {
+        id: 'prefix_0b6c28e0-a117-4a9e-9a0d-60f0992edbee'
+      }
+
+      var result = normalize.expandPK(context, options);
+
+      assert(result.id === '0b6c28e0-a117-4a9e-9a0d-60f0992edbee');
+    });
+
+    it("casts uuids with capitals", function() {
+      var context = {
+        attributes: {
+          id: {
+            type: 'uuid',
+            primaryKey: true
+          }
+        }
+      };
+
+      var options = {
+        id: '0B6C28E0-A117-4A9E-9A0D-60F0992EDBEE'
+      }
+
+      var result = normalize.expandPK(context, options);
+
+      assert(result.id === '0B6C28E0-A117-4A9E-9A0D-60F0992EDBEE');
+    });
+  });
+
 });


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/117363295

This patch adds coercion behavior when a model attribute is specified as a `uuid` type and designated a primary key. This is similar to existing behavior in waterline where numbers and strings are coerced, and this patch extends this behavior. In other words, you can pass `{id: 'foo_0b6c28e0-a117-4a9e-9a0d-60f0992edbee'}` to a `.where` and waterline will strip the `"foo_"` from the id.

Note that this will not coerce uuid types that aren't primary keys. There's no mechanism in waterline for this (that I know of), so it'd be a larger change, both behavior and code-wise.
